### PR TITLE
Add Python 3.9 to GitHub Actions

### DIFF
--- a/.github/workflows/melodiam-tests.yml
+++ b/.github/workflows/melodiam-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     services:
       melodiam-db:


### PR DESCRIPTION
Since Python 3.9 is available - why not?